### PR TITLE
Update macOS runners in workflow configuration

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -43,10 +43,10 @@ jobs:
         # Runners https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#standard-github-hosted-runners-for-public-repositories
         # - ubuntu-latest: ubuntu x64
         # - ubuntu-24.04-arm: ubuntu arm64
-        # - macos-13: mac intel
         # - macos-14: mac arm64
+        # - macos-15-intel: mac intel
         # - windows-latest: windows x64
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-15-intel, windows-latest]
 
     steps:
     # Check out repository with submodules for C++ extensions


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for building wheels, specifically adjusting the set of macOS runners used for CI builds. The main change is replacing the older Intel-based macOS runner with a newer version.

Platform runner updates:

* The `os` matrix in `.github/workflows/wheels.yml` now uses `macos-15-intel` instead of `macos-13`, ensuring CI builds run on the latest Intel-based macOS runner.
* The commented list of available runners was updated to reflect the use of `macos-15-intel` and removal of `macos-13`.